### PR TITLE
Fix/windows config compile error

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -16,6 +16,7 @@ App::App(const char *title) {
     title_ = title;
 
     InitWindow(width_, height_, title_);
+    ToggleFullscreen();
     SetTargetFPS(100);
 }
 

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -41,7 +41,7 @@ std::string ConfigManager::get_config_dir() {
         // AppData / Local
         char path[MAX_PATH];
         if (SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, path))) {
-            config_dir = std::string(path) + "\\STARMAN\";
+            config_dir = std::string(path) + R"(\STARMAN\)";
         }
     #elif defined(__linux__) || defined(__APPLE__)
         const char *homedir = getenv("HOME");


### PR DESCRIPTION
Should fix compile error on windows. Using raw string literals now, instead of using escape characters in config directory path.